### PR TITLE
attempt to stop scrolling on mobile when drawing.

### DIFF
--- a/src/components/main/ideabox/index.js
+++ b/src/components/main/ideabox/index.js
@@ -146,6 +146,7 @@ class IdeaboxContainer extends React.Component {
 
   handleTouchMove = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     var X = e.touches[0].pageX - e.target.offsetLeft;
     let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
     var Y = e.touches[0].pageY - e.target.getBoundingClientRect().top - scrollTop;


### PR DESCRIPTION
When on a mobile device and trying to draw in the Idea Box, the window scrolls. Attempting to stop that scrolling. Was unable to replicate this issue with dev tools, so merging and deploying in order to test on an actual mobile device.